### PR TITLE
fix a crash in Transpiler, ignore transpiled code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Thumbs.db
 Desktop.ini
 .DS_Store
 .desktop
+/Drizzle.Ported/Translated

--- a/Drizzle.Transpiler/Program.cs
+++ b/Drizzle.Transpiler/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -213,6 +213,7 @@ namespace Drizzle.Transpiler
             foreach (var (name, script) in scripts)
             {
                 var path = Path.Combine(SourcesDest, $"Movie.{name}.cs");
+                Directory.CreateDirectory(SourcesDest);
                 using var file = new StreamWriter(path);
 
                 OutputSingleMovieScript(name, script, file, ctx);


### PR DESCRIPTION
- Fixes a transpiler crash when the destination directory does not exist by creating it.
- Adds the transpiled code to .gitignore.